### PR TITLE
Provide errorCode that makes sense if read() returns 0

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -110,7 +110,10 @@ int WiFiClient::available() {
       uint8_t b;
       int numread = ::read(psock, &b, 1);
       if (numread < 1) {
-        errorCode = errno;
+        if (numread == 0) // EOF
+          errorCode = ECONNRESET;
+        else
+          errorCode = errno;
         // EAGAIN means timeout
         if (errorCode == EAGAIN)
           errorCode = 0;


### PR DESCRIPTION
Unix read() returning 0 is not an error condition but EOF. This means errno doesn't contain any reasonable value. Fake errno value since for our case this is a error condition.