### PR TITLE
Improve error handling in WiFiClient write method

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -130,7 +130,14 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size) {
     return 0;
   }
 
-  return ::write(psock, buf, size);
+  auto ret = ::write(psock, buf, size);
+  if (ret == -1) {
+    if (errno)
+      errorCode = errno;
+    else
+      errorCode = ECONNRESET;
+  }
+  return ret;
 }
 
 int WiFiClient::available() {


### PR DESCRIPTION
A return value of -1 here seems to indicate a connection reset, so don't ignore it.