### PR TITLE
Move logging.h out of WiFiServer's extern "C" block

### DIFF
--- a/src/WiFiServer.cpp
+++ b/src/WiFiServer.cpp
@@ -20,8 +20,14 @@
 #include <string.h>
 #include <signal.h>
 
-extern "C" {
+// logging.h declares `arduino::log(...)` (C++ namespace). Must NOT live inside
+// `extern "C"` — on Apple Clang that gives the C++ declaration C linkage and
+// later collides with libc's `extern double log(double)` from <math.h>
+// (pulled transitively from Arduino.h -> <memory>). Linux GCC is tolerant of
+// this misuse but Clang isn't.
 #include "logging.h"
+
+extern "C" {
 #include "utility/debug.h"
 #include "utility/wifi_spi.h"
 }


### PR DESCRIPTION
## Summary

`WiFiServer.cpp` currently does:

```cpp
extern "C" {
#include "logging.h"
#include "utility/debug.h"
#include "utility/wifi_spi.h"
}
```

`logging.h` declares `arduino::log(...)` in a C++ namespace. With the include inside `extern "C" { ... }`, that declaration ends up with C linkage and then collides with libc's `extern "C" double log(double)` from `<math.h>` — pulled transitively via `Arduino.h` → `<memory>` → `<cmath>`. Apple Clang reports `error: conflicting types for 'log'` and aborts; Linux GCC silently tolerates the misuse, which is why this never surfaced before.

This PR moves `#include "logging.h"` outside the `extern "C"` block (matching the placement that `WiFiClient.cpp` already uses at line 30) and adds a comment explaining why future edits must not relocate it back inside.

## Context

Hit while bringing up the macOS-native portduino build — see firmware PR meshtastic/firmware#10300 for the full bring-up. The other two `.cpp` files in this library are already correct:
- `WiFiClient.cpp` — `#include "logging.h"` is at line 30, after its `extern "C"` block at line 20–25. No change.
- `WiFiUdp.cpp` — does not include `logging.h` at all. No change.

## After this lands

The downstream cleanup chain is:
1. (this PR) — fix the WiFi submodule.
2. `meshtastic/framework-portduino` — bump the `libraries/WiFi` submodule pointer to the merged commit.
3. `meshtastic/platform-native` — bump the `framework-portduino` git ref in `platform.json`.
4. `meshtastic/firmware` PR #10300 — drop `bin/patch-framework-portduino-darwin.py` and its `extra_scripts` entry in `[env:native-macos]`, then bump `portduino_base.platform` to the new `platform-native` commit.

## Test plan

- [x] Verified the same byte-level transformation builds `meshtasticd` cleanly on macOS arm64 (Apple Clang) — the firmware-side pre-build patcher applies the equivalent reordering and the resulting binary boots in SimRadio mode.
- [ ] CI on this repo has no native build target, but the change is syntactic only — no runtime path is added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)