### PR TITLE
Drop verbose accept() log spam from WiFiServer

### DIFF
--- a/src/WiFiServer.cpp
+++ b/src/WiFiServer.cpp
@@ -96,7 +96,6 @@ void WiFiServer::begin() {
 WiFiClient WiFiServer::available(byte *status) {
 
   assert(psock);
-  log(SysWifi, LogVerbose, "calling accept");
 
   struct sockaddr_in cli_addr;
   socklen_t clilen = sizeof(cli_addr);
@@ -112,8 +111,6 @@ WiFiClient WiFiServer::available(byte *status) {
       portduinoCheckNotNeg(s, "accept failed");
     }
   }
-
-  log(SysWifi, LogVerbose, "accept=%d", s);
 
   return WiFiClient(s);
 }


### PR DESCRIPTION
## Summary

Two `log(SysWifi, LogVerbose, ...)` calls in `WiFiServer::available()` fire on every poll of the accept loop, which `meshtasticd`'s main loop hits hundreds of times per second. Output:

```
calling accept
accept=0
calling accept
accept=0
...
```

The intent was clearly that they stay quiet at default verbosity — but portduino's `logv()` in `cores/portduino/logging.cpp` ignores the `level` argument entirely and unconditionally writes to `Serial`. So `LogVerbose` is just as loud as `LogInfo`.

## What this changes

Drops the two log calls. Nothing else.

```diff
 WiFiClient WiFiServer::available(byte *status) {

   assert(psock);
-  log(SysWifi, LogVerbose, "calling accept");

   struct sockaddr_in cli_addr;
   ...
   }

-  log(SysWifi, LogVerbose, "accept=%d", s);
-
   return WiFiClient(s);
 }
```

## Why not fix `logv()` to honor the level?

Tempting, but wider blast radius — every other `LogVerbose` call site across the framework would suddenly go silent, and some of them probably are useful at a higher verbosity setting that doesn't exist yet. This PR is the minimal surgical fix for the `meshtasticd` noise problem; level-aware logging can be a separate change.

## Why these two lines have no diagnostic value

- `accept failed` (real error path) is already logged by `portduinoCheckNotNeg(s, "accept failed")` a few lines above the removed second log.
- The `EWOULDBLOCK` / harmless-error fast-path is the **steady state** for an idle listening socket — exactly the state we don't want spamming output.

## Test plan

- [x] Built native-macos `meshtasticd` with this submodule pinned at the new commit
- [x] Verified `meshtasticd -s` is silent during idle accept polling
- [x] Verified TCP client connect/disconnect still works (real `accept failed` errors would still surface via `portduinoCheckNotNeg`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)